### PR TITLE
fix: bugfix for issue #21

### DIFF
--- a/src/main/java/io/cucumber/junit/CucumberSerenityRunner.java
+++ b/src/main/java/io/cucumber/junit/CucumberSerenityRunner.java
@@ -27,6 +27,7 @@ import net.serenitybdd.cucumber.suiteslicing.CucumberSuiteSlicer;
 import net.serenitybdd.cucumber.suiteslicing.ScenarioFilter;
 import net.serenitybdd.cucumber.suiteslicing.TestStatistics;
 import net.serenitybdd.cucumber.suiteslicing.WeightedCucumberScenarios;
+import net.serenitybdd.cucumber.util.PathUtils;
 import net.serenitybdd.cucumber.util.Splitter;
 import net.thucydides.core.ThucydidesSystemProperty;
 import net.thucydides.core.guice.Injectors;
@@ -335,7 +336,7 @@ public class CucumberSerenityRunner extends ParentRunner<FeatureRunner> {
     private Predicate<FeatureRunner> forIncludedFeatures(WeightedCucumberScenarios weightedCucumberScenarios) {
         return featureRunner -> {
             String featureName = FeatureRunnerExtractors.extractFeatureName(featureRunner);
-            String featurePath = Paths.get(FeatureRunnerExtractors.featurePathFor(featureRunner)).getFileName().toString();
+            String featurePath =  PathUtils.getAsFile(FeatureRunnerExtractors.featurePathFor(featureRunner)).getName();
             boolean matches = weightedCucumberScenarios.scenarios.stream().anyMatch(scenario -> featurePath.equals(scenario.featurePath));
             LOGGER.debug("{} in filtering '{}' in {}", matches ? "Including" : "Not including", featureName, featurePath);
             return matches;

--- a/src/main/java/net/serenitybdd/cucumber/suiteslicing/CucumberScenarioLoader.java
+++ b/src/main/java/net/serenitybdd/cucumber/suiteslicing/CucumberScenarioLoader.java
@@ -9,10 +9,11 @@ import gherkin.ast.Scenario;
 import gherkin.ast.ScenarioDefinition;
 import gherkin.ast.ScenarioOutline;
 import gherkin.ast.Tag;
+import net.serenitybdd.cucumber.util.PathUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.util.Collections;
@@ -56,7 +57,7 @@ public class CucumberScenarioLoader {
                     .stream()
                     .filter(child -> asList(ScenarioOutline.class, Scenario.class).contains(child.getClass()))
                     .map(scenarioDefinition -> new WeightedCucumberScenario(
-                        new File(cucumberFeature.getUri()).getName(),
+                        PathUtils.getAsFile(cucumberFeature.getUri()).getName(),
                         cucumberFeature.getGherkinFeature().getFeature().getName(),
                         scenarioDefinition.getName(),
                         scenarioWeightFor(cucumberFeature, scenarioDefinition),

--- a/src/main/java/net/serenitybdd/cucumber/suiteslicing/CucumberScenarioVisualiser.java
+++ b/src/main/java/net/serenitybdd/cucumber/suiteslicing/CucumberScenarioVisualiser.java
@@ -1,6 +1,8 @@
 package net.serenitybdd.cucumber.suiteslicing;
 
 import com.google.gson.GsonBuilder;
+
+import net.serenitybdd.cucumber.util.PathUtils;
 import net.thucydides.core.util.EnvironmentVariables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +42,8 @@ public class CucumberScenarioVisualiser {
             Files.createDirectories(Paths.get(outputDirectory()));
             List<WeightedCucumberScenarios> slices = new CucumberScenarioLoader(newArrayList(rootFolderURI), testStatistics).load().sliceInto(sliceCount);
             List<VisualisableCucumberScenarios> visualisedSlices = CucumberScenarioVisualiser.sliceIntoForks(forkCount, slices);
-            String jsonFile = String.format("%s/%s-slice-config-%s-forks-in-each-of-%s-slices-using-%s.json", outputDirectory(), rootFolderURI.getPath().replaceAll("[:/]", "-"), forkCount, sliceCount, testStatistics);
+            String jsonFile = String.format("%s/%s-slice-config-%s-forks-in-each-of-%s-slices-using-%s.json", outputDirectory(), PathUtils
+                .getAsFile(rootFolderURI).getPath().replaceAll("[:/]", "-"), forkCount, sliceCount, testStatistics);
             Files.write(Paths.get(jsonFile), new GsonBuilder().setPrettyPrinting().create().toJson(visualisedSlices).getBytes());
             LOGGER.info("Wrote visualisation as JSON for {} slices -> {}", visualisedSlices.size(), jsonFile);
         } catch (Exception e) {

--- a/src/main/java/net/serenitybdd/cucumber/util/PathUtils.java
+++ b/src/main/java/net/serenitybdd/cucumber/util/PathUtils.java
@@ -1,0 +1,40 @@
+package net.serenitybdd.cucumber.util;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.Objects;
+
+import io.cucumber.core.model.Classpath;
+
+public class PathUtils {
+
+    private PathUtils() {
+    }
+
+    public static File getAsFile(URI cucumberFeatureUri) {
+        Objects.requireNonNull(cucumberFeatureUri, "cucumber feature URI cannot be null");
+        String featureFilePath;
+        switch (cucumberFeatureUri.getScheme()) {
+            case "file": {
+                try {
+                    featureFilePath = cucumberFeatureUri.toURL().getPath();
+                    break;
+                } catch (MalformedURLException e) {
+                    throw new IllegalArgumentException("Cannot convert cucumber feature URI to URL", e);
+                }
+            }
+            case "classpath": {
+                featureFilePath = Classpath.resourceName(cucumberFeatureUri);
+                break;
+            }
+            default:
+                throw new IllegalArgumentException("Cannot get cucumber feature file from URI");
+        }
+        return new File(featureFilePath);
+    }
+
+    public static File getAsFile(String cucumberFeatureUri) {
+        return getAsFile(URI.create(cucumberFeatureUri));
+    }
+}


### PR DESCRIPTION
#### Summary of this PR
Fix loading scenarios in suiteslicing mechanizm.
Issue was caused by changes in cucumber-jvm 4.8.0 (previously used 4.2.0). With latter cucumber version there is an issue to create `java.io.File` from `java.net.URI`, because now cucumber stores feature file URI in different format, causing error in File constructor (see related issue for details).

#### Description of PR:
Create utility class `PathUtils` to correctly transform URI strings like `file:/path/to/feature` or `classpath:/path/to/feature` into existing files. This class is applied in methods `CucumberScenarioLoader#getScenarios` and `CucumberSerenityRunner#forIncludedFeatures`

Fix was tested on windows 10 environment.
#### How should this be manually tested?
Run Serenity tests using suiteslicing mechanizm (i.e. using properties `serenity.batch.count` and `serenity.batch.number`). Also, `CucumberScenarioLoaderTest` test is auto fixed.
#### Relevant tickets
This is a fix for issue #21