### PR TITLE
Add Context Tag provider strategy to meta-inf services

### DIFF
--- a/src/main/resources/META-INF/services/net.thucydides.core.statistics.service.TagProviderStrategy
+++ b/src/main/resources/META-INF/services/net.thucydides.core.statistics.service.TagProviderStrategy
@@ -1,0 +1,1 @@
+net.serenitybdd.cucumber.service.CucumberTagProviderStrategy


### PR DESCRIPTION
This will fix a bug related with the use of contexts in cucumber 4.